### PR TITLE
fix outdated coin3d source sha256

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   - url: https://github.com/coin3d/coin/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: c8554e8659008dc3cb3b96407eff92c28c98d52a83e9a07c6c6f6e7db18062b0
+    sha256: 086ecf84479e4bc59397568638488c2e6c08d8aa811779bab93cda5509f79d59
 
   - url: https://github.com/coin3d/superglu/archive/superglu-{{ superglue_version }}.tar.gz
     sha256: f408adcfb706e7c781db9c218ef9e8ba56d43995ccb61dffad5f6154c34f17d6


### PR DESCRIPTION
coin3d v4.0.3 was re-released to fix abi incompatibility https://github.com/coin3d/coin/issues/528#issuecomment-2333456630

4.0.3 did not build when the pr was merged because the checksum had changed so there's no need to increase build number. @looooo 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
